### PR TITLE
ci: publish container image to GHCR

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,52 @@
+name: Publish to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=long
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/publish-ghcr.yml`) that builds the existing `Dockerfile` and pushes the image to GitHub Container Registry.

The repo already publishes to a private `docker.ntag.fr` registry via `deploy.yml`; this workflow runs alongside it and exposes a public image at `ghcr.io/ntag/lyrics.ovh` so other operators (myself included) can deploy without having to mirror the source and build it themselves.

### Triggers

- Push to `main`
- Push of a `v*` tag
- Manual `workflow_dispatch`

### Tags published

Using `docker/metadata-action`:

- `main` (branch ref)
- `latest` (only on default branch)
- `vX.Y.Z` (on git tags)
- `sha-<short>` and the full commit SHA

### Permissions

Uses the workflow-scoped `GITHUB_TOKEN` with `packages: write` — no extra secrets needed. The package will appear under the `NTag` user/org once the workflow runs on `main`; you may want to mark it public from the package settings page after the first successful publish.

Happy to adjust the tag scheme, drop `latest`, change the trigger set, or split it into a separate workflow file — whatever fits your preference.

## Test plan

- [ ] Workflow runs on push to `main`
- [ ] `ghcr.io/ntag/lyrics.ovh:main` and `:latest` are pushed
- [ ] A subsequent `vX.Y.Z` tag publishes `:vX.Y.Z`